### PR TITLE
Merge feature/improve-projection into master

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Custom" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="MessDetectorOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCSFixerOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
+  <component name="PHPCodeSnifferOptionsConfiguration">
+    <option name="highlightLevel" value="WARNING" />
+    <option name="transferred" value="true" />
+  </component>
   <component name="PhpIncludePathManager">
     <include_path>
       <path value="$PROJECT_DIR$/vendor/doctrine/common" />
@@ -54,9 +64,15 @@
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.3" />
+  <component name="PhpStanOptionsConfiguration">
+    <option name="transferred" value="true" />
+  </component>
   <component name="PhpUnit">
     <phpunit_settings>
       <PhpUnitSettings custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" />
     </phpunit_settings>
+  </component>
+  <component name="PsalmOptionsConfiguration">
+    <option name="transferred" value="true" />
   </component>
 </project>

--- a/src/Projection/AllowResult.php
+++ b/src/Projection/AllowResult.php
@@ -22,7 +22,7 @@
 		}
 
 		public static function isAllow(int $value): bool {
-			return $value & self::ALLOW !== 0;
+			return ($value & self::ALLOW) !== 0;
 		}
 
 		public static function isExplicitAllow(int $value): bool {
@@ -30,7 +30,7 @@
 		}
 
 		public static function isDeny(int $value): bool {
-			return $value & self::DENY !== 0;
+			return ($value & self::DENY) !== 0;
 		}
 
 		public static function isExplicitDeny(int $value): bool {
@@ -38,7 +38,7 @@
 		}
 
 		public static function isExplicit(int $value): bool {
-			return $value & self::IS_EXPLICIT !== 0;
+			return ($value & self::IS_EXPLICIT) !== 0;
 		}
 
 		public static function from(bool $allowed, bool $explicit): int {

--- a/src/Projection/AllowResult.php
+++ b/src/Projection/AllowResult.php
@@ -1,0 +1,47 @@
+<?php
+	namespace DaybreakStudios\DoctrineQueryDocument\Projection;
+
+	final class AllowResult {
+		/**
+		 * Indicates that the result was explicit, meaning that the projection didn't allow or deny the query by
+		 * default; that the queried path was one of the keys in the projection.
+		 */
+		public const IS_EXPLICIT = 1;
+
+		public const ALLOW = 2;
+		public const DENY = 4;
+
+		private function __construct() {}
+
+		public static function allow(bool $explicit = false): int {
+			return self::ALLOW | (self::IS_EXPLICIT * (int)$explicit);
+		}
+
+		public static function deny(bool $explicit = false): int {
+			return self::DENY | (self::IS_EXPLICIT * (int)$explicit);
+		}
+
+		public static function isAllow(int $value): bool {
+			return $value & self::ALLOW !== 0;
+		}
+
+		public static function isExplicitAllow(int $value): bool {
+			return self::isAllow($value) && self::isExplicit($value);
+		}
+
+		public static function isDeny(int $value): bool {
+			return $value & self::DENY !== 0;
+		}
+
+		public static function isExplicitDeny(int $value): bool {
+			return self::isDeny($value) && self::isExplicit($value);
+		}
+
+		public static function isExplicit(int $value): bool {
+			return $value & self::IS_EXPLICIT !== 0;
+		}
+
+		public static function from(bool $allowed, bool $explicit): int {
+			return $allowed ? self::allow($explicit) : self::deny($explicit);
+		}
+	}

--- a/src/Projection/Projection.php
+++ b/src/Projection/Projection.php
@@ -57,7 +57,7 @@
 		}
 
 		/**
-		 * Queries the projection for the given path, returning an integer representation of the {@see AllowResult}
+		 * Queries the projection for the given path, returning an integer representation of the {@see QueryResult}
 		 * for the query.
 		 *
 		 * @param string $path
@@ -77,7 +77,7 @@
 				return true;
 
 			$parts = explode('.', $path);
-			$result = AllowResult::from($this->isAllowedByDefault(), false);
+			$result = QueryResult::from($this->isAllowedByDefault(), false);
 
 			foreach ($parts as $part) {
 				if (!isset($current[$part]))
@@ -86,7 +86,7 @@
 				$value = $current[$part];
 
 				if (!is_array($value)) {
-					$result = AllowResult::from($value, true);
+					$result = QueryResult::from($value, true);
 					break;
 				}
 
@@ -97,19 +97,19 @@
 		}
 
 		public function isAllowed(string $path, bool $useCache = true): bool {
-			return AllowResult::isAllow($this->query($path, $useCache));
+			return QueryResult::isAllow($this->query($path, $useCache));
 		}
 
 		public function isAllowedExplicitly(string $path, bool $useCache = true): bool {
-			return AllowResult::isExplicitAllow($this->query($path, $useCache));
+			return QueryResult::isExplicitAllow($this->query($path, $useCache));
 		}
 
 		public function isDenied(string $path, bool $useCache = true): bool {
-			return AllowResult::isDeny($this->query($path, $useCache));
+			return QueryResult::isDeny($this->query($path, $useCache));
 		}
 
 		public function isDeniedExplicitly(string $path, bool $useCache = true): bool {
-			return AllowResult::isExplicitDeny($this->query($path, $useCache));
+			return QueryResult::isExplicitDeny($this->query($path, $useCache));
 		}
 
 		/**

--- a/src/Projection/Projection.php
+++ b/src/Projection/Projection.php
@@ -26,12 +26,12 @@
 			$this->nodes = $nodes;
 			$this->cache = new ProjectionPathCache();
 
-			if (sizeof($nodes) === 0)
+			if (count($nodes) === 0)
 				$this->default = true;
 			else {
 				// If an element is not matched, the default behavior is the opposite of the value of the first element.
-				// For example, for an include projection, any element not found in $nodes should be rejected (the opposite
-				// of the value of the include projections, whose values are all true).
+				// For example, for an include projection, any element not found in $nodes should be rejected (the
+				// opposite of the value of the include projections, whose values are all true).
 
 				$current = reset($nodes);
 
@@ -57,12 +57,17 @@
 		}
 
 		/**
-		 * @param string $path
+		 * Queries the projection for the given path, returning an integer representation of the {@see AllowResult}
+		 * for the query.
 		 *
-		 * @return bool
+		 * @param string $path
+		 * @param bool   $useCache if `false`, skip checking for a cached result; the new result will be written to
+		 *                         the cache
+		 *
+		 * @return int
 		 */
-		public function isAllowed(string $path): bool {
-			if ($this->cache->has($path))
+		public function query(string $path, bool $useCache = true): int {
+			if ($useCache && $this->cache->has($path))
 				return $this->cache->get($path);
 
 			$current = $this->getNodes();
@@ -72,32 +77,39 @@
 				return true;
 
 			$parts = explode('.', $path);
-			$result = null;
+			$result = AllowResult::from($this->isAllowedByDefault(), false);
 
 			foreach ($parts as $part) {
-				if (!isset($current[$part])) {
-					$result = $this->isAllowedByDefault();
-
+				if (!isset($current[$part]))
 					break;
-				}
 
 				$value = $current[$part];
 
 				if (!is_array($value)) {
-					$result = $value;
-
+					$result = AllowResult::from($value, true);
 					break;
 				}
 
 				$current = $value;
 			}
 
-			// If $current is an array after processing all path parts, the path has child nodes and needs to be
-			// allowed so that it can be processed later.
-			if ($result === null && is_array($current))
-				$result = true;
-
 			return $this->cache->set($path, $result);
+		}
+
+		public function isAllowed(string $path, bool $useCache = true): bool {
+			return AllowResult::isAllow($this->query($path, $useCache));
+		}
+
+		public function isAllowedExplicitly(string $path, bool $useCache = true): bool {
+			return AllowResult::isExplicitAllow($this->query($path, $useCache));
+		}
+
+		public function isDenied(string $path, bool $useCache = true): bool {
+			return AllowResult::isDeny($this->query($path, $useCache));
+		}
+
+		public function isDeniedExplicitly(string $path, bool $useCache = true): bool {
+			return AllowResult::isExplicitDeny($this->query($path, $useCache));
 		}
 
 		/**
@@ -115,7 +127,7 @@
 				if (!$this->isAllowed($path))
 					continue;
 
-				if (is_array($value) && $count = sizeof($value)) {
+				if (is_array($value) && count($value) > 0) {
 					if (isset($value[0])) {
 						if (is_array($value[0])) {
 							foreach ($value as $index => $item)

--- a/src/Projection/ProjectionPathCache.php
+++ b/src/Projection/ProjectionPathCache.php
@@ -9,7 +9,7 @@
 
 		/**
 		 * @param string $path
-		 * @param int   $value {@see AllowResult}
+		 * @param int   $value {@see QueryResult}
 		 *
 		 * @return int
 		 */
@@ -27,7 +27,7 @@
 		}
 
 		/**
-		 * {@see AllowResult}
+		 * {@see QueryResult}
 		 *
 		 * @param string $path
 		 *

--- a/src/Projection/ProjectionPathCache.php
+++ b/src/Projection/ProjectionPathCache.php
@@ -3,17 +3,17 @@
 
 	class ProjectionPathCache {
 		/**
-		 * @var array
+		 * @var array<string, int>
 		 */
 		protected $data = [];
 
 		/**
 		 * @param string $path
-		 * @param bool   $value
+		 * @param int   $value {@see AllowResult}
 		 *
-		 * @return bool
+		 * @return int
 		 */
-		public function set(string $path, bool $value): bool {
+		public function set(string $path, int $value): int {
 			return $this->data[$path] = $value;
 		}
 
@@ -27,11 +27,13 @@
 		}
 
 		/**
+		 * {@see AllowResult}
+		 *
 		 * @param string $path
 		 *
-		 * @return bool
+		 * @return int
 		 */
-		public function get(string $path): bool {
+		public function get(string $path): int {
 			if (!$this->has($path)) {
 				throw new \InvalidArgumentException($path . ' does not exist in the cache. Use ' . static::class .
 					'::has() to check first!');

--- a/src/Projection/QueryResult.php
+++ b/src/Projection/QueryResult.php
@@ -1,7 +1,7 @@
 <?php
 	namespace DaybreakStudios\DoctrineQueryDocument\Projection;
 
-	final class AllowResult {
+	final class QueryResult {
 		/**
 		 * Indicates that the result was explicit, meaning that the projection didn't allow or deny the query by
 		 * default; that the queried path was one of the keys in the projection.

--- a/tests/Projection/ProjectionTest.php
+++ b/tests/Projection/ProjectionTest.php
@@ -1,7 +1,7 @@
 <?php
 	namespace Projection;
 
-	use DaybreakStudios\DoctrineQueryDocument\Projection\AllowResult;
+	use DaybreakStudios\DoctrineQueryDocument\Projection\QueryResult;
 	use DaybreakStudios\DoctrineQueryDocument\Projection\Projection;
 	use PHPUnit\Framework\TestCase;
 
@@ -12,20 +12,20 @@
 			]);
 
 			$result = $projection->query('a.b.c');
-			$this->assertEquals(AllowResult::allow(true), $result, 'reports explicit allows');
+			$this->assertEquals(QueryResult::allow(true), $result, 'reports explicit allows');
 
 			$result = $projection->query('1.2.3');
-			$this->assertEquals(AllowResult::deny(), $result, 'reports implicit denies');
+			$this->assertEquals(QueryResult::deny(), $result, 'reports implicit denies');
 
 			$projection = Projection::fromFields([
 				'a.b.c' => false,
 			]);
 
 			$result = $projection->query('a.b.c');
-			$this->assertEquals(AllowResult::deny(true), $result, 'reports explicit denies');
+			$this->assertEquals(QueryResult::deny(true), $result, 'reports explicit denies');
 
 			$result = $projection->query('1.2.3');
-			$this->assertEquals(AllowResult::allow(), $result, 'reports implicit allows');
+			$this->assertEquals(QueryResult::allow(), $result, 'reports implicit allows');
 
 			$projection = Projection::fromFields([
 				'a.b' => true,
@@ -33,7 +33,7 @@
 
 			$result = $projection->query('a.b.c');
 			$this->assertEquals(
-				AllowResult::allow(true),
+				QueryResult::allow(true),
 				$result,
 				'explicit allows on parent nodes are inherited by child nodes',
 			);
@@ -44,7 +44,7 @@
 
 			$result = $projection->query('a.b.c');
 			$this->assertEquals(
-				AllowResult::deny(true),
+				QueryResult::deny(true),
 				$result,
 				'explict denys on parent nodes are inherited by child nodes',
 			);

--- a/tests/Projection/ProjectionTest.php
+++ b/tests/Projection/ProjectionTest.php
@@ -1,0 +1,166 @@
+<?php
+	namespace Projection;
+
+	use DaybreakStudios\DoctrineQueryDocument\Projection\AllowResult;
+	use DaybreakStudios\DoctrineQueryDocument\Projection\Projection;
+	use PHPUnit\Framework\TestCase;
+
+	class ProjectionTest extends TestCase {
+		public function testQuery() {
+			$projection = Projection::fromFields([
+				'a.b.c' => true,
+			]);
+
+			$result = $projection->query('a.b.c');
+			$this->assertEquals(AllowResult::allow(true), $result, 'reports explicit allows');
+
+			$result = $projection->query('1.2.3');
+			$this->assertEquals(AllowResult::deny(), $result, 'reports implicit denies');
+
+			$projection = Projection::fromFields([
+				'a.b.c' => false,
+			]);
+
+			$result = $projection->query('a.b.c');
+			$this->assertEquals(AllowResult::deny(true), $result, 'reports explicit denies');
+
+			$result = $projection->query('1.2.3');
+			$this->assertEquals(AllowResult::allow(), $result, 'reports implicit allows');
+
+			$projection = Projection::fromFields([
+				'a.b' => true,
+			]);
+
+			$result = $projection->query('a.b.c');
+			$this->assertEquals(
+				AllowResult::allow(true),
+				$result,
+				'explicit allows on parent nodes are inherited by child nodes',
+			);
+
+			$projection = Projection::fromFields([
+				'a.b' => false,
+			]);
+
+			$result = $projection->query('a.b.c');
+			$this->assertEquals(
+				AllowResult::deny(true),
+				$result,
+				'explict denys on parent nodes are inherited by child nodes',
+			);
+		}
+
+		public function testIsAllowedByDefault() {
+			$projection = Projection::fromFields([
+				'a.b.c' => true,
+				'1.2.3' => true,
+			]);
+
+			$this->assertFalse($projection->isAllowedByDefault(), 'infers default deny from allow-list');
+
+			$projection = Projection::fromFields([
+				'a.b.c' => false,
+				'1.2.3' => false,
+			]);
+
+			$this->assertTrue($projection->isAllowedByDefault(), 'infers default allow from deny-list');
+
+			$projection = Projection::fromFields([
+				'a.b.c' => true,
+				'1.2.3' => false,
+			]);
+
+			$this->assertFalse($projection->isAllowedByDefault(), 'infers default from initial value in mixed list');
+		}
+
+		public function testIsDenied() {
+			$projection = Projection::fromFields([
+				'a.b.c' => false,
+			]);
+
+			$this->assertTrue($projection->isDenied('a.b.c'), 'matches explicit deny');
+
+			$projection = Projection::fromFields([
+				'a.b.c' => true,
+			]);
+
+			$this->assertTrue($projection->isDenied('1.2.3'), 'matches implicit deny');
+		}
+
+		public function testIsDeniedExplicitly() {
+			$projection = Projection::fromFields([
+				'a.b.c' => false,
+			]);
+
+			$this->assertTrue($projection->isDeniedExplicitly('a.b.c'), 'matches explicit deny');
+
+			$projection = Projection::fromFields([
+				'a.b.c' => true,
+			]);
+
+			$this->assertFalse($projection->isDeniedExplicitly('1.2.3'), 'does not match implicit deny');
+		}
+
+		public function testIsAllowed() {
+			$projection = Projection::fromFields([
+				'a.b.c' => true,
+			]);
+
+			$this->assertTrue($projection->isAllowed('a.b.c'), 'matches explicit allow');
+
+			$projection = Projection::fromFields([
+				'a.b.c' => false,
+			]);
+
+			$this->assertTrue($projection->isAllowed('1.2.3'), 'matches implicit allow');
+		}
+
+		public function testIsAllowedExplicitly() {
+			$projection = Projection::fromFields([
+				'a.b.c' => true,
+			]);
+
+			$this->assertTrue($projection->isAllowedExplicitly('a.b.c'), 'matches explicit allow');
+
+			$projection = Projection::fromFields([
+				'a.b.c' => false,
+			]);
+
+			$this->assertFalse($projection->isAllowedExplicitly('1.2.3'), 'does not match implicit allow');
+		}
+
+		public function testFilter() {
+			$projection = Projection::fromFields([
+				'a' => true,
+				'b' => true,
+				'd' => true,
+			]);
+
+			$this->assertEquals(
+				['a' => 1, 'b' => 2, 'd' => 4],
+				$projection->filter([
+					'a' => 1,
+					'b' => 2,
+					'c' => 3,
+					'd' => 4,
+				]),
+				'removes unmatched keys from allow-list',
+			);
+
+			$projection = Projection::fromFields([
+				'a' => false,
+				'c' => false,
+			]);
+
+			$this->assertEquals(
+				['b' => 2, 'd' => 4],
+				$projection->filter([
+					'a' => 1,
+					'b' => 2,
+					'c' => 3,
+					'd' => 4,
+				]),
+				'removes matched keys from deny-list',
+			);
+		}
+	}


### PR DESCRIPTION
## What's Changed
- Projection query results now differentiate between explicit and implicit results, meaning that it is possible to detect e.g. if a path was denied because the projection was an allow-list and the path wasn't found in the list. See [Projection Examples](#projection-examples) for more details.

## Projection Examples
The `Projection` class now includes a suite of methods for testing exactly why a path did or did not pass the projection.

Starting with the most basic of the methods, `query()`, which returns an integer describing the result of the query. The integer is a bitmask (see [`QueryResult`](https://github.com/LartTyler/doctrine-query-document/blob/83a1d14e47f0e49c2c6c87ef1596f206c3357015/src/Projection/QueryResult.php)) representing the states a result can take.

```php
use DaybreakStudios\DoctrineQueryDocument\Projection\Projection;
use DaybreakStudios\DoctrineQueryDocument\Projection\QueryResult;

// ===== Allow List =====
$projection = Projection::fromFields([
    'a.b.c' => true,
]);

// Our projection is an allow-list, and the path "a.b.c" is part of the list, so
// it is both `allowed` and `explicit`.
assert($projection->query('a.b.c') === QueryResult::ALLOW | QueryResult::IS_EXPLICIT);

// Our projection is an allow-list, and the path "1.2.3" is not part of the list, so
// it is only `denied`.
assert($projection->query('1.2.3') === QueryResult::DENY);

// ===== Deny List =====
$projection = Projection::fromFields([
    'a.b.c' => false,
]);

// Our projection is a deny-list, and the path "a.b.c" is part of the list, so
// it is both `denied` and `explicit`.
assert($projection->query('a.b.c') === QueryResult::DENY | QueryResult::IS_EXPLICIT);

// Our projection is a deny-list, and the path "1.2.3" is not part of the list, so
// it is only `allowed`.
assert($projection->query('1.2.3') === QueryResult::ALLOW);
```

In addition to the existing `Projection::isAllowed()` method, there are several new methods you can use to easily test the results of a query without using `QueryResult` directly.

```php
use DaybreakStudios\DoctrineQueryDocument\Projection\Projection;

$projection = Projection::fromFields([
    'a.b.c' => true,
]);

// An explicit allow is still an allow
assert($projection->isAllowed('a.b.c'));

// Explicitly allowed because the path is present in the allow-list
assert($projection->isAllowedExplicitly('a.b.c'));

// Denied by default because the path is not present in the allow-list
assert($projection->isDenied('1.2.3'));

// Not explicitly denied
assert($projection->isDeniedExplicitly('1.2.3') === false);

$projection = Projection::fromFields([
    '1.2.3' => false,
]);

// An explicit deny is still a deny
assert($projection->isDenied('1.2.3'));

// Explicitly denied because the path is present in the deny-list
assert($projection->isDeniedExplicitly('1.2.3'));

// Allowed by default because the path is not present in the deny-list
assert($projection->isAllowed('a.b.c'));

// Not explicitly allowed
assert($projection->isAllowedExplicitly('a.b.c') === false);
```
