### PR TITLE
Merge feature/improved-matching into master

### DIFF
--- a/src/Projection/Projection.php
+++ b/src/Projection/Projection.php
@@ -163,7 +163,10 @@
 		}
 
 		protected function getMatchAllValue(array $nodes): ?bool {
-			return isset($nodes[static::MATCH_ALL_SYMBOL]) ? (bool)$nodes[static::MATCH_ALL_SYMBOL] : null;
+			if (null !== $value = $nodes[static::MATCH_ALL_SYMBOL])
+				return (bool)$value;
+
+			return null;
 		}
 
 		/**

--- a/src/Projection/Projection.php
+++ b/src/Projection/Projection.php
@@ -22,13 +22,14 @@
 		 *
 		 * @param bool[] $nodes
 		 */
-		protected function __construct(array $nodes) {
+		public function __construct(array $nodes, bool $default = null) {
 			$this->nodes = $nodes;
 			$this->cache = new ProjectionPathCache();
 
-			// For projections with no nodes, all paths are allowed
-			if (count($nodes) === 0)
-				$this->default = true;
+			if ($default !== null)
+				$this->default = $default;
+			else if (count($nodes) === 0)
+				$this->default = true; // For projections with no nodes, all paths are allowed
 			else {
 				// If an element is not matched, the default behavior is the opposite of the value of the first element.
 				// For example, for an include projection, any element not found in $nodes should be rejected (the
@@ -144,12 +145,13 @@
 		}
 
 		/**
-		 * @param array $fields
+		 * @param array     $fields
+		 * @param bool|null $default
 		 *
 		 * @return static
 		 */
-		public static function fromFields(array $fields) {
-			return new static(static::toNodes($fields));
+		public static function fromFields(array $fields, bool $default = null) {
+			return new static(static::toNodes($fields), $default);
 		}
 
 		/**

--- a/src/Projection/Projection.php
+++ b/src/Projection/Projection.php
@@ -72,26 +72,40 @@
 			if ($useCache && $this->cache->has($path))
 				return $this->cache->get($path);
 
-			$result = QueryResult::from($this->isAllowedByDefault(), false);
 			$current = $this->getNodes();
 
 			if (!$current)
-				return $result;
+				return $this->getDefaultResult();
 
+			$result = QueryResult::empty();
 			$parts = explode('.', $path);
 
 			foreach ($parts as $part) {
-				if (!isset($current[$part]))
-					break;
+				if (!isset($current[$part])) {
+					if (null !== $allValue = $this->getMatchAllValue($current))
+						$result = QueryResult::from($allValue, true);
+					else
+						$result = $this->getDefaultResult();
 
-				$value = $current[$part];
-
-				if (!is_array($value)) {
-					$result = QueryResult::from($value, true);
 					break;
 				}
 
-				$current = $value;
+				$current = $current[$part];
+
+				if (!is_array($current)) {
+					$result = QueryResult::from($current, true);
+					break;
+				}
+			}
+
+			// If the loop ended with an empty result, the query was for an ancestor of a path contained in the list if
+			// $current is still an array. If it isn't an array, then we should fall back on the default match behavior
+			// for the projection.
+			if (QueryResult::isEmpty($result)) {
+				if (is_array($current))
+					$result = QueryResult::allow();
+				else
+					$result = $this->getDefaultResult();
 			}
 
 			return $this->cache->set($path, $result);
@@ -142,6 +156,14 @@
 			}
 
 			return $output;
+		}
+
+		protected function getDefaultResult(): int {
+			return QueryResult::from($this->isAllowedByDefault(), false);
+		}
+
+		protected function getMatchAllValue(array $nodes): ?bool {
+			return isset($nodes[static::MATCH_ALL_SYMBOL]) ? (bool)$nodes[static::MATCH_ALL_SYMBOL] : null;
 		}
 
 		/**

--- a/src/Projection/ProjectionInterface.php
+++ b/src/Projection/ProjectionInterface.php
@@ -11,6 +11,8 @@
 	 * be well-documented that the `$useCache` argument has no effect.
 	 */
 	interface ProjectionInterface {
+		public const MATCH_ALL_SYMBOL = '*';
+
 		/**
 		 * Returns an integer representing the result of the query.
 		 *

--- a/src/Projection/QueryResult.php
+++ b/src/Projection/QueryResult.php
@@ -3,6 +3,11 @@
 
 	final class QueryResult {
 		/**
+		 * Indicates that the query result has not yet been set.
+		 */
+		public const EMPTY = 0;
+
+		/**
 		 * Indicates that the result was explicit, meaning that the projection didn't allow or deny the query by
 		 * default; that the queried path was one of the keys in the projection.
 		 */
@@ -12,6 +17,10 @@
 		public const DENY = 4;
 
 		private function __construct() {}
+
+		public static function empty(): int {
+			return self::EMPTY;
+		}
 
 		public static function allow(bool $explicit = false): int {
 			return self::ALLOW | (self::IS_EXPLICIT * (int)$explicit);
@@ -39,6 +48,10 @@
 
 		public static function isExplicit(int $value): bool {
 			return ($value & self::IS_EXPLICIT) !== 0;
+		}
+
+		public static function isEmpty(int $value): bool {
+			return $value === self::EMPTY;
 		}
 
 		public static function from(bool $allowed, bool $explicit): int {

--- a/src/Projection/QueryResult.php
+++ b/src/Projection/QueryResult.php
@@ -57,4 +57,14 @@
 		public static function from(bool $allowed, bool $explicit): int {
 			return $allowed ? self::allow($explicit) : self::deny($explicit);
 		}
+
+		public static function describe(int $value): string {
+			if (self::isEmpty($value))
+				return 'empty';
+
+			$output = self::isExplicit($value) ? 'explicit ' : '';
+			$output .= self::isAllow($value) ? 'allow' : 'deny';
+
+			return $output;
+		}
 	}

--- a/tests/Projection/ProjectionTest.php
+++ b/tests/Projection/ProjectionTest.php
@@ -208,4 +208,43 @@
 				'removes matched keys from deny-list',
 			);
 		}
+
+		public function testAllowedChildNode() {
+			$projection = Projection::fromFields(
+				[
+					'child.field' => true,
+				],
+				false,
+			);
+
+			$this->assertTrue($projection->isAllowed('child'));
+			$this->assertFalse($projection->isAllowedExplicitly('child'));
+			$this->assertTrue($projection->isAllowedExplicitly('child.field'));
+			$this->assertFalse($projection->isAllowed('child.bar'));
+
+			$projection = Projection::fromFields(
+				[
+					'child' => true,
+				],
+				false,
+			);
+
+			$this->assertTrue($projection->isAllowedExplicitly('child'));
+			$this->assertTrue($projection->isAllowedExplicitly('child.field'));
+			$this->assertFalse($projection->isAllowed('bar'));
+		}
+
+		public function testMatchAllFallback() {
+			$projection = Projection::fromFields(
+				[
+					'child.*' => false,
+					'child.foo' => true,
+				],
+				true
+			);
+
+			$this->assertFalse($projection->isAllowed('child.bar'));
+			$this->assertTrue($projection->isDeniedExplicitly('child.bar'));
+			$this->assertTrue($projection->isAllowedExplicitly('child.foo'));
+		}
 	}


### PR DESCRIPTION
## What's Changed
- Added a `$default` argument to constructors to allow default match behavior to be explicitly set instead of inferred from input.
- Added the "*" match-all operator to allow control of matching behavior for groups.
- Added `QueryResult::describe()` method for debugging / logging plain-english forms of match results.